### PR TITLE
Add flex column width

### DIFF
--- a/flex-grid-framework.styl
+++ b/flex-grid-framework.styl
@@ -37,8 +37,17 @@ row()
 
 /* Columns
 ------------------------------------------------*/
-col(number-of-cols)
-	width (number-of-cols * column) + (((number-of-cols - 1) * 2) * margin)
+col(number-of-cols = flex)
+	if (number-of-cols is a 'unit')
+    width (number-of-cols * column) + (((number-of-cols - 1) * 2) * margin)
+
+	if (number-of-cols == flex)
+    -webkit-box-flex: auto;
+    -moz-box-flex: auto;
+    -webkit-flex: auto;
+    -ms-flex: auto;
+    flex: auto;
+
 	margin-right margin
 	margin-left margin
 

--- a/site/assets/css/style.css
+++ b/site/assets/css/style.css
@@ -246,6 +246,9 @@ _____________________________________________________ */
 .featured {
   color: #fe9600;
 }
+.commented {
+  color: #808080;
+}
 /* Yellow bars
 _____________________________________________________ */
 .yellow-bar-1 {
@@ -353,6 +356,19 @@ _____________________________________________________ */
   margin-bottom: 5px;
   height: 30px;
   width: 98.95949999999999%;
+  margin-right: 0.52083%;
+  margin-left: 0.52083%;
+}
+.yellow-bar-flex {
+  background-color: #f7cb34;
+  margin-top: 5px;
+  margin-bottom: 5px;
+  height: 30px;
+  -webkit-box-flex: auto;
+  -moz-box-flex: auto;
+  -webkit-flex: auto;
+  -ms-flex: auto;
+  flex: auto;
   margin-right: 0.52083%;
   margin-left: 0.52083%;
 }

--- a/site/assets/stylus/style.styl
+++ b/site/assets/stylus/style.styl
@@ -203,6 +203,9 @@ _____________________________________________________ */
 .featured
 	color pumpkin
 
+.commented
+	color grey
+
 /* Yellow bars
 _____________________________________________________ */
 .yellow-bar-1
@@ -252,6 +255,10 @@ _____________________________________________________ */
 .yellow-bar-12
 	yellow-bar()
 	col(12)
+
+.yellow-bar-flex
+	yellow-bar()
+	col(flex)
 
 .yellow-bar-x
 	yellow-bar()

--- a/site/index.html
+++ b/site/index.html
@@ -162,6 +162,40 @@
 
 		</div>
 
+				<!-- Item features - equal width columns
+		================================================== -->
+		<div class="title-container">
+			<h4 class="title-lv4 yellow">Equal width columns</h4>
+		</div>
+
+		<div class="code">
+<pre class="pre">
+<code>
+.container
+  row()
+
+.example-flex
+  <span class="featured">col()</span>
+
+.example-flex
+  <span class="featured">col()</span>
+
+.example-flex
+  <span class="featured">col()</span>
+
+</code>
+</pre>
+
+		</div> <!-- / code -->
+
+		<div class="demo-row">
+
+			<div class="yellow-bar-flex"></div>
+			<div class="yellow-bar-flex"></div>
+			<div class="yellow-bar-flex"></div>
+
+		</div>
+
 		<!-- Item features - offset
 		================================================== -->
 		<div class="title-container">

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>Flex Grid Framework</title>
-		
+
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0">
 		<link rel="icon" href="assets/icons/favicon-32.png" sizes="32x32">
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
@@ -113,7 +113,8 @@
 		================================================== -->
 		<div class="title-container">
 			<h3 class="title-lv3"><span class="yellow">Items</span> features</h3>
-			<h4 class="title-lv4 yellow">Choose your combination between 12 responsive columns</h4>
+			<h4 class="title-lv4 yellow">Choose your combination between 12 percentage based columns and a 'flex'
+			column to fill in the remaining space.</h4>
 		</div>
 
 		<div class="code">
@@ -138,6 +139,12 @@
 .example-12
   <span class="featured">col(12)</span>
 
+.example-2
+  <span class="featured">col(2)</span>
+
+.example-flex
+  <span class="featured">col(flex)</span>
+
 </code>
 </pre>
 
@@ -150,6 +157,8 @@
 			<div class="yellow-bar-5"></div>
 			<div class="yellow-bar-7"></div>
 			<div class="yellow-bar-12"></div>
+			<div class="yellow-bar-2"></div>
+			<div class="yellow-bar-flex"></div>
 
 		</div>
 

--- a/site/index.html
+++ b/site/index.html
@@ -143,7 +143,7 @@
   <span class="featured">col(2)</span>
 
 .example-flex
-  <span class="featured">col(flex)</span>
+  <span class="featured">col(flex)</span> <span class="commented">/* col() == col(flex) */</span>
 
 </code>
 </pre>


### PR DESCRIPTION
One of the most useful features of flexbox is the ability for columns to distribute and fill in the remaining width. By allowing 'flex' as the default value, implementers can simply use `.col()` (or `.col(flex)`) on 3 divs to create equal-width columns with the proper margins.
