### PR TITLE
Change content-align to justify

### DIFF
--- a/flex-grid-framework.styl
+++ b/flex-grid-framework.styl
@@ -49,7 +49,7 @@ offset(number-of-offset)
 
 /* Flex Container
 ------------------------------------------------*/
-content-align(content-value)
+justify(content-value)
 	if (content-value == left)
     -webkit-box-pack start
     -webkit-justify-content flex-start

--- a/site/assets/stylus/style.styl
+++ b/site/assets/stylus/style.styl
@@ -159,19 +159,19 @@ _____________________________________________________ */
 	row()
 
 .c-align-left
-	content-align(left)
+	justify(left)
 
 .c-align-right
-	content-align(right)
+	justify(right)
 
 .c-align-center
-	content-align(center)
+	justify(center)
 
 .c-align-between
-	content-align(between)
+	justify(between)
 
 .c-align-around
-	content-align(around)
+	justify(around)
 
 .v-align-top
 	vertical-align(top)

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>Flex Grid Framework</title>
-		
+
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0">
 		<link rel="icon" href="assets/icons/favicon-32.png" sizes="32x32">
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
@@ -196,7 +196,7 @@
 <code>
 .container
   row()
-  <span class="featured">content-align(left)</span>
+  <span class="featured">justify(left)</span>
 
 .example-3
   col(3)
@@ -215,7 +215,7 @@
 <code>
 .container
   row()
-  <span class="featured">content-align(right)</span>
+  <span class="featured">justify(right)</span>
 
 .example-3
   col(3)
@@ -240,7 +240,7 @@
 <code>
 .container
   row()
-  <span class="featured">content-align(center)</span>
+  <span class="featured">justify(center)</span>
 
 .example-3
   col(3)
@@ -265,7 +265,7 @@
 <code>
 .container
   row()
-  <span class="featured">content-align(between)</span>
+  <span class="featured">justify(between)</span>
 
 .example-2
   col(2)
@@ -302,7 +302,7 @@
 <code>
 .container
   row()
-  <span class="featured">content-align(around)</span>
+  <span class="featured">justify(around)</span>
 
 .example-2
   col(2)


### PR DESCRIPTION
CSS has an `align-content` property, but the `content-align` mixin in this library is really an alias to the CSS `justify-content` property.  The mixin has been renamed to reduce confusion. See issue #3.
