### PR TITLE
Fix import in .styl files installed from NPM

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,13 @@
+var stylus = require('stylus')
+  , path = require('path')
+  , nodes = stylus.nodes
+  , utils = stylus.utils
+
+exports = module.exports = function () {
+  return function (style) {
+    style.include(__dirname)
+  }
+}
+
+exports.version = require(path.join(__dirname, 'package.json')).version
+exports.path = __dirname

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "email": "afonsopacifer@live.com",
     "url": "http://afonsopacifer.com"
   },
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/afonsopacifer/flex-grid-framework"


### PR DESCRIPTION
Fix to: `failed to locate @import file: flex-grid-framework` on .styl files.
